### PR TITLE
Create minisnip.vim

### DIFF
--- a/syntax/minisnip.vim
+++ b/syntax/minisnip.vim
@@ -1,0 +1,32 @@
+" Vim syntax file
+" Language:      minisnip
+" Created by:    Robert Hicks <gowther@zoho.com>
+" Last Change:   2017-08-20
+"
+" To enable syntax highlighting you just need to set the filetype
+" to 'minisnip'.
+"
+" Adding something like the following in your vimrc will do it
+" automatically for you:
+"
+" autocmd BufRead,BufNewFile /path/to/minisnips/* set filetype=minisnip
+"
+" You can add it as a grouping as well:
+"
+" augroup MiniSnip
+"     autocmd!
+"     autocmd BufRead,BufNewFile /path/to/minisnips/* set filetype=minisnip
+" augroup END
+"
+
+if exists("b:current_syntax")
+    finish
+endif
+
+" Get the minisnip defined delimiters
+exe "syntax match minisnipKeyword /" . g:minisnip_startdelim . "/"
+exe "syntax match minisnipKeyword /" . g:minisnip_enddelim . "/"
+
+highlight default link minisnipKeyword Keyword
+
+let b:current_syntax = "minisnip"


### PR DESCRIPTION
This is a simple syntax file for minisnips. Instructions for enabling it are in the file. Sometimes it's nice to see where the delimiters start and end.

I tested it on the defaults {{++}} and the delimiters that I use ||++||.
