### PR TITLE
Support multiple directories in g:minisnip_dir

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+/doc/tags

--- a/autoload/minisnip.vim
+++ b/autoload/minisnip.vim
@@ -3,18 +3,20 @@ function! minisnip#ShouldTrigger()
     let l:cword = matchstr(getline('.'), '\v\f+%' . col('.') . 'c')
 
     " look for a snippet by that name
-    let l:snippetfile = g:minisnip_dir . '/' . l:cword
-    let l:ft_snippetfile = g:minisnip_dir . '/_' . &filetype . '_' . l:cword
-    if filereadable(l:ft_snippetfile)
-        " filetype snippets override general snippets
-        let l:snippetfile = l:ft_snippetfile
-    endif
+    for l:dir in split(g:minisnip_dir, ':')
+        let l:snippetfile = l:dir . '/' . l:cword
+        let l:ft_snippetfile = l:dir . '/_' . &filetype . '_' . l:cword
+        if filereadable(l:ft_snippetfile)
+            " filetype snippets override general snippets
+            let l:snippetfile = l:ft_snippetfile
+        endif
 
-    " make sure the snippet exists
-    if filereadable(l:snippetfile)
-        let s:snippetfile = l:snippetfile
-        return 1
-    endif
+        " make sure the snippet exists
+        if filereadable(l:snippetfile)
+            let s:snippetfile = l:snippetfile
+            return 1
+        endif
+    endfor
 
     return search(g:minisnip_delimpat, 'e')
 endfunction

--- a/doc/minisnip.txt
+++ b/doc/minisnip.txt
@@ -44,11 +44,12 @@ CONFIGURATION                                          *minisnip-configuration*
 
 -------------------------------------------------------------------------------
                                                              *'g:minisnip_dir'*
-Default: $HOME . '/.vim/minisnip'
+Default: '~/.vim/minisnip'
 
-This allows you to specify where minisnip looks for snippet files. Add this
-line to your `.vimrc`: >
-    let g:minisnip_dir = '/path/to/directory'
+A colon-separated list of directories to look for snippet files, similar to
+$PATH. The first match will be used. For example to share system-wide
+snippets: >
+    let g:minisnip_dir = '/usr/share/minisnip:~/.vim/minisnip'
 <
 
 -------------------------------------------------------------------------------
@@ -66,7 +67,7 @@ example: >
                                                         *'g:minisnip_enddelim'*
 Defaults: '{{+', '+}}'
 
-The start and end delimeters of the placeholder string to use. For example,
+The start and end delimiters of the placeholder string to use. For example,
 with the default values, a sample snippet could look like this: >
     <!DOCTYPE html>
     <html lang='en'>
@@ -83,7 +84,7 @@ with the default values, a sample snippet could look like this: >
                                                       *'g:minisnip_evalmarker'*
 Default: '~'
 
-Marks a template as meant to be executed as vimscript. With the default value,
+Marks a template as meant to be executed as VimScript. With the default value,
 this looks something like: >
     It has been {{+~localtime()+}} seconds since the Unix epoch
 <
@@ -113,7 +114,7 @@ MISCELLANEOUS                                          *minisnip-miscellaneous*
 
 Syntax highlighting for minisnips:
 
-If you would like to have the minisnip delimeters hightlighted for better
+If you would like to have the minisnip delimiters highlighted for better
 visibility in your minisnip files, add the following to your `.vimrc`: >
-    autocmd BufRead,BufNewFile /path/to/minisnips/* set filetype=minisnip
+    autocmd BufRead,BufNewFile */minisnip/_* setlocal filetype=minisnip
 <


### PR DESCRIPTION
The specific reason I added this is because I wanted to add support for
minisnip in vim-go (it already supports ultisnips and neosnippet).

However, with just a single directory I can't add the vim-go snippet
directory.

This converts g:minisnip_dir to a colon-separated list of paths, like
the PATH environment variable.

There are several ways to do this; I just chose this as the easiest and
most backwards compatible way.