### PR TITLE
Use dd instead of J to remove the empty line

### DIFF
--- a/autoload/minisnip.vim
+++ b/autoload/minisnip.vim
@@ -35,7 +35,7 @@ function! minisnip#Minisnip()
         " insert the snippet
         call append(line('.'), lns)
         " remove the empty line before the snippet
-        normal! J
+        normal! "_dd
         " select the first placeholder
         call s:SelectPlaceholder()
     else


### PR DESCRIPTION
`J` will trigger folding, whereas `dd` does not. This seems to be a bug
in Vim, I think, since it folds things that shouldn't even be folded.

To reproduce you can use:

	:set foldmethod=syntax
	:syn match FoldTest "\v(^\s*//.*\n)+" fold

And then add a snippet like this:

	// hello {{++}}
	{{++}}

And after triggering that the first line is "folded", which shouldn't
happen at all AFAIK? After opening the fold I can't close it again with
`zc` (just "E490: No fold found").

Like I said, I suspect this is a bug in Vim(?), but in the meanwhile I
don't see any downsides to using `dd`?