### PR TITLE
replace exactly the keyword

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,13 +1,11 @@
 language: vim
 
 before_script: |
-  git clone https://github.com/junegunn/vader.vim.git
-  git clone https://github.com/joereynolds/vim-minisnip
+  git clone --depth 1 https://github.com/junegunn/vader.vim.git
 
-  git clone https://github.com/vim/vim
+  git clone --depth 1 https://github.com/vim/vim
   cd vim
   ./configure --with-features=huge
-  make
   sudo make install
   cd -
 
@@ -15,9 +13,7 @@ script: |
   vim -Nu <(cat << VIMRC
   filetype off
   set rtp+=vader.vim
-  set rtp+=vim-minisnip
   set rtp+=.
-  set rtp+=after
   filetype plugin indent on
   syntax enable
   VIMRC) -c 'Vader! test/*' > /dev/null

--- a/snippets/multilinetest
+++ b/snippets/multilinetest
@@ -1,0 +1,2 @@
+This is a multiline
+test snippet!

--- a/test/minisnip.vader
+++ b/test/minisnip.vader
@@ -40,82 +40,82 @@ Do (Press tab to get the placeholder text):
 Expect (No replacements to have taken place):
   placeholder
 
-Given (A buffer with one minisnip placeholder):
+Given (A buffer with one multiline minisnip placeholder):
   multilinetest
 
 Do (Perform the replacement):
   A\<Tab>
 
-Expect (The buffer to have the replacement text inside):
+Expect (The buffer to have the multiline replacement text inside):
   This is a multiline
   test snippet!
 
-Given (A buffer with one minisnip placeholder):
+Given (A buffer with one prefixed multiline minisnip placeholder):
   |multilinetest
 
 Do (Perform the replacement):
   A\<Tab>
 
-Expect (The buffer to have the replacement text inside):
+Expect (The buffer to have the prefixed and suffixed multiline replacement text inside):
   |This is a multiline
   test snippet!
 
-Given (A buffer with one minisnip placeholder):
-  multilinetest|
+Given (A buffer with one suffixed multiline minisnip placeholder):
+  multilinetestX
 
 Do (Perform the replacement):
   $i\<Tab>
 
-Expect (The buffer to have the replacement text inside):
+Expect (The buffer to have the prefixed and suffixed multiline replacement text inside):
   This is a multiline
-  test snippet!|
+  test snippet!X
 
-Given (A buffer with one minisnip placeholder):
-  |multilinetest|
+Given (A buffer with one prefixed and suffixed multiline minisnip placeholder):
+  |multilinetestX
 
 Do (Perform the replacement):
   $i\<Tab>
 
-Expect (The buffer to have the replacement text inside):
+Expect (The buffer to have the prefixed and suffixed multiline replacement text inside):
   |This is a multiline
-  test snippet!|
+  test snippet!X
 
-Given (A buffer with one minisnip placeholder):
+Given (A buffer with one indented multiline minisnip placeholder):
    multilinetest
 
 Do (Perform the replacement):
   A\<Tab>
 
-Expect (The buffer to have the replacement text inside):
+Expect (The buffer to have the prefixed and suffixed multiline replacement text inside):
    This is a multiline
    test snippet!
 
-Given (A buffer with one minisnip placeholder):
+Given (A buffer with one indented and prefixed multiline minisnip placeholder):
    |multilinetest
 
 Do (Perform the replacement):
   A\<Tab>
 
-Expect (The buffer to have the replacement text inside):
+Expect (The buffer to have the prefixed and suffixed multiline replacement text inside):
    |This is a multiline
    test snippet!
 
-Given (A buffer with one minisnip placeholder):
-   multilinetest|
+Given (A buffer with one indented and suffixed multiline minisnip placeholder):
+   multilinetestX
 
 Do (Perform the replacement):
   $i\<Tab>
 
-Expect (The buffer to have the replacement text inside):
+Expect (The buffer to have the prefixed and suffixed multiline replacement text inside):
    This is a multiline
-   test snippet!|
+   test snippet!X
 
-Given (A buffer with one minisnip placeholder):
-   |multilinetest|
+Given (A buffer with one prefixed and suffixed multiline minisnip placeholder):
+   |multilinetestX
 
 Do (Perform the replacement):
   $i\<Tab>
 
-Expect (The buffer to have the replacement text inside):
+Expect (The buffer to have the prefixed and suffixed multiline replacement text inside):
    |This is a multiline
-   test snippet!|
+   test snippet!X

--- a/test/minisnip.vader
+++ b/test/minisnip.vader
@@ -39,3 +39,83 @@ Do (Press tab to get the placeholder text):
 
 Expect (No replacements to have taken place):
   placeholder
+
+Given (A buffer with one minisnip placeholder):
+  multilinetest
+
+Do (Perform the replacement):
+  A\<Tab>
+
+Expect (The buffer to have the replacement text inside):
+  This is a multiline
+  test snippet!
+
+Given (A buffer with one minisnip placeholder):
+  |multilinetest
+
+Do (Perform the replacement):
+  A\<Tab>
+
+Expect (The buffer to have the replacement text inside):
+  |This is a multiline
+  test snippet!
+
+Given (A buffer with one minisnip placeholder):
+  multilinetest|
+
+Do (Perform the replacement):
+  $i\<Tab>
+
+Expect (The buffer to have the replacement text inside):
+  This is a multiline
+  test snippet!|
+
+Given (A buffer with one minisnip placeholder):
+  |multilinetest|
+
+Do (Perform the replacement):
+  $i\<Tab>
+
+Expect (The buffer to have the replacement text inside):
+  |This is a multiline
+  test snippet!|
+
+Given (A buffer with one minisnip placeholder):
+   multilinetest
+
+Do (Perform the replacement):
+  A\<Tab>
+
+Expect (The buffer to have the replacement text inside):
+   This is a multiline
+   test snippet!
+
+Given (A buffer with one minisnip placeholder):
+   |multilinetest
+
+Do (Perform the replacement):
+  A\<Tab>
+
+Expect (The buffer to have the replacement text inside):
+   |This is a multiline
+   test snippet!
+
+Given (A buffer with one minisnip placeholder):
+   multilinetest|
+
+Do (Perform the replacement):
+  $i\<Tab>
+
+Expect (The buffer to have the replacement text inside):
+   This is a multiline
+   test snippet!|
+
+Given (A buffer with one minisnip placeholder):
+   |multilinetest|
+
+Do (Perform the replacement):
+  $i\<Tab>
+
+Expect (The buffer to have the replacement text inside):
+   |This is a multiline
+   test snippet!|


### PR DESCRIPTION
This commit allows for replacing just the snippet keyword, no more, no
less. Some tests were added and the viml syntax was cleaned up.