### PR TITLE
Fix minisnip replace wrong part of line on tab indent file

### DIFF
--- a/autoload/minisnip.vim
+++ b/autoload/minisnip.vim
@@ -45,7 +45,7 @@ function! minisnip#Minisnip() abort
         " delete the snippet
         execute ':normal! '.strchars(s:cword).'x'
 
-        if col('.') >= (s:begcol - strchars(s:cword))
+        if virtcol('.') >= (s:begcol - strchars(s:cword))
            " there is something following the snippet
            let l:keepEndOfLine = 1
            let l:endOfLine = strpart(getline(line('.')), (col('.') - 1))

--- a/autoload/minisnip.vim
+++ b/autoload/minisnip.vim
@@ -3,7 +3,7 @@ let s:placeholder_texts = []
 function! minisnip#ShouldTrigger() abort
     silent! unlet! s:snippetfile
     let s:cword = matchstr(getline('.'), '\v\f+%' . col('.') . 'c')
-    let s:begcol = col('.')
+    let s:begcol = virtcol('.')
 
     " look for a snippet by that name
     for l:dir in split(g:minisnip_dir, s:pathsep())

--- a/test/minisnip.vader
+++ b/test/minisnip.vader
@@ -13,6 +13,15 @@ Do (Perform the replacement):
 Expect (The buffer to have the replacement text inside):
   This is a test snippet
 
+Given (A buffer with one minisnip placeholder indented by tab):
+  	test
+
+Do (Perform the replacement):
+  A\<Tab>
+
+Expect (The buffer to have the replacement text inside):
+  	This is a test snippet
+
 Given (A buffer with a named placeholder):
   namedplaceholder
 

--- a/test/minisnip.vader
+++ b/test/minisnip.vader
@@ -13,15 +13,6 @@ Do (Perform the replacement):
 Expect (The buffer to have the replacement text inside):
   This is a test snippet
 
-Given (A buffer with one minisnip placeholder indented by tab):
-  	test
-
-Do (Perform the replacement):
-  A\<Tab>
-
-Expect (The buffer to have the replacement text inside):
-  	This is a test snippet
-
 Given (A buffer with a named placeholder):
   namedplaceholder
 
@@ -146,3 +137,21 @@ Do (Perform the replacement):
 
 Expect (Expand the final placeholder last):
   one two
+
+Given (A buffer with one minisnip placeholder indented by tab):
+  	test
+
+Do (Perform the replacement):
+  A\<Tab>
+
+Expect (The buffer to have the replacement text inside):
+  	This is a test snippet
+
+Given (A buffer with one minisnip placeholder indented by tab, followed by some text):
+  	test| and other text
+
+Do (Perform the replacement):
+  0f|cl\<Tab>
+
+Expect (The buffer to have the replacement text in correct position):
+  	This is a test snippet and other text


### PR DESCRIPTION
Our code base uses tab to indent 😞 