### PR TITLE
fix cursor location

### DIFF
--- a/autoload/minisnip.vim
+++ b/autoload/minisnip.vim
@@ -41,7 +41,9 @@ function! minisnip#Minisnip() abort
 
         " remove the snippet keyword
         " go to the position at the beginning of the snippet
-        execute ':normal! '.(s:begcol - strchars(s:cword)).'|'
+        let pos = getpos('.')
+        let pos[2] = s:begcol - strchars(s:cword)
+        call setpos('.', pos)
         " delete the snippet
         execute ':normal! '.strchars(s:cword).'x'
 


### PR DESCRIPTION
`|` is not useful to move cursor. When type tab key on following code.

```go
package main

func main() {
	err
}
```
This goes:
```go
package main

func main() {
rif err != nil {
		return err
	}
}
```
