### PR TITLE
Fix help tag

### DIFF
--- a/doc/minisnip.txt
+++ b/doc/minisnip.txt
@@ -137,7 +137,7 @@ This will automatically fill the `#define` line with the value entered on the
 
 -------------------------------------------------------------------------------
                                                  *'g:minisnip_finalstartdelim'*
-                                                        *'g:minisnip_enddelim'*
+                                                   *'g:minisnip_finalenddelim'*
 Defaults: '{{-', '-}}'
 
 The start and end delimiters of the final placeholder string to use. While the

--- a/test/minisnip.vader
+++ b/test/minisnip.vader
@@ -155,3 +155,12 @@ Do (Perform the replacement):
 
 Expect (The buffer to have the replacement text in correct position):
   	This is a test snippet and other text
+
+Given (some text, test the helptags):
+  error:
+
+Do (generate the helptags):
+  :execute ':normal! A' . execute(':silent! helptags ./doc')
+
+Expect (no error in generating the helptags):
+  error:


### PR DESCRIPTION
The `g:minisnip_finalenddelim` helptag was messed up. I fixed it and added a test which checks the helptags.