### PR TITLE
keep the register clean

### DIFF
--- a/test/minisnip.vader
+++ b/test/minisnip.vader
@@ -164,3 +164,20 @@ Do (generate the helptags):
 
 Expect (no error in generating the helptags):
   error:
+
+Given (lorem placeholder):
+  lorem namedplaceholder
+
+Execute (Clear search history):
+  for _ in range(&history)
+    call histdel('/', -1)
+  endfor
+
+Do (search "lorem" and replace the placeholder):
+  /lorem\<Cr>A\<Tab>ipsum
+
+Expect (replacement works as expected):
+  lorem ipsum
+
+Execute (Assert search register is still "lorem"):
+  AssertEqual "lorem", @/


### PR DESCRIPTION
`keeppatterns` only assures, that the highlighting is not affected.
Therefore, it is necessary to delete the last entry in the search history
when performing a search.

Furthermore, the value of the `@/` value has to be restored.

Additionally, the unnamed register is not corrupted anymore when the
placeholder gets replaced with some value

Note that using the most recent version of vim, the text which is deleted when using the select mode, is put in the unnamed register. Therefore, replacing the text from a placeholder will still change the unnamed register.