### PR TITLE
Use <C-y> instead of <CR> to accept completion

### DIFF
--- a/doc/minisnip.txt
+++ b/doc/minisnip.txt
@@ -42,8 +42,8 @@ MAPPINGS                                                    *minisnip-mappings*
 -------------------------------------------------------------------------------
                     *minisnip_<C-x><C-t>*
 <C-x><C-t>          Start |ins-completion| for the snippet. Press <C-t> again
-                    to go to the next snippet; press <CR> or <Tab> to complete
-                    it.
+                    to go to the next snippet; press <C-y> or <Tab> to
+                    complete it.
 
 ===============================================================================
 CONFIGURATION                                          *minisnip-configuration*
@@ -142,8 +142,8 @@ Defaults: '{{-', '-}}'
 
 The start and end delimiters of the final placeholder string to use. While the
 normal placeholders will be dealt with in the order they appear in the snippet,
-these placeholders will be targeted last.>
-    # BEGIN FUNCTON {{++}}
+these placeholders will be targeted last. >
+    # BEGIN FUNCTION {{++}}
     {{--}}
     # END FUNCTION {{+~\~1+}}
 <

--- a/plugin/minisnip.vim
+++ b/plugin/minisnip.vim
@@ -43,5 +43,5 @@ endif
 if !hasmapto('<Plug>(minisnip-complete)')
     imap <C-x><C-t> <Plug>(minisnip-complete)
     inoremap <expr> <C-t> pumvisible() ?  "\<C-n>" : "\<C-t>"
-    imap <expr> <CR> pumvisible() ? "\<Tab>" : "\<CR>"
+    imap <expr> <C-y> pumvisible() ? "\<Tab>" : "\<C-y>"
 endif


### PR DESCRIPTION
<CR> isn't the standard Vim mapping to accept the completion, <C-y> is.
This is just a personal preference that snuck in when I wrote the
completion (#6).

Fixes #42 and #43