### PR TITLE
Auto correct snippet indent after inserting

### DIFF
--- a/autoload/minisnip.vim
+++ b/autoload/minisnip.vim
@@ -38,6 +38,7 @@ function! minisnip#Minisnip() abort
         " adjust the indentation, use the current line as reference
         let l:ws = matchstr(getline(line('.')), '^\s\+')
         let l:lns = map(readfile(s:snippetfile), 'empty(v:val)? v:val : l:ws.v:val')
+        let l:nlines = len(l:lns)
 
         " remove the snippet keyword
         " go to the position at the beginning of the snippet
@@ -73,6 +74,9 @@ function! minisnip#Minisnip() abort
 
         " go to the beginning of the snippet
         execute ':normal! '.(s:begcol - strchars(s:cword)).'|'
+
+        " auto indent
+        execute ':normal! =' . l:nlines . 'j'
 
         " select the first placeholder
         call s:SelectPlaceholder()


### PR DESCRIPTION
After inserting a snippet, use vim's indent feature `=` to auto-indent the inserted snippet.

This means the snippets files themselves don't need to use the same indentation as the file in which they're inserted (a classic example is Python, where some source files use indents and others use spaces. Using `=` will fix the indentation in the source file regardless of how it's defined in the snippet).