### PR TITLE
Added minimal.vimrc to make debugging and testing easier

### DIFF
--- a/minimal.vimrc
+++ b/minimal.vimrc
@@ -1,0 +1,19 @@
+" install: curl https://raw.githubusercontent.com/prabirshrestha/vim-lsp/master/minimal.vimrc -o /tmp/minimal.vimrc
+" uninstall: rm /tmp/plug.vim && rm -rf /tmp/plugged
+" run vim/neovim with minimal.vimrc
+" vim -u minimal.vimrc
+" :PlugInstall
+
+set nocompatible hidden laststatus=2
+
+if !filereadable('/tmp/plug.vim')
+  silent !curl --insecure -fLo /tmp/plug.vim
+    \ https://raw.githubusercontent.com/junegunn/vim-plug/master/plug.vim
+endif
+
+source /tmp/plug.vim
+call plug#begin('/tmp/plugged')
+Plug 'joereynolds/vim-minisnip'
+let g:minisnip_dir='/tmp/plugged/snip'
+call plug#end()
+set expandtab


### PR DESCRIPTION
This is a simple vimrc that can be used for testing pull requests and debugging. adding this should encorage people to contribute. In addition people that are having issues with conflicting plugins can use this to quickly check if minisnip is the cause or if it is another plugin. This way less issues will be submited that are not the fault of minisnip.