### PR TITLE
Option g:minisnip_backreffirst

### DIFF
--- a/autoload/minisnip.vim
+++ b/autoload/minisnip.vim
@@ -152,8 +152,8 @@ function! s:SelectPlaceholder() abort
             \"\\=\"'\" . substitute(get(
             \    s:placeholder_texts,
             \    g:minisnip_backreffirst ?
-						\        str2nr(submatch(1)) :
-						\        len(s:placeholder_texts) - str2nr(submatch(1)), ''
+            \        str2nr(submatch(1)) :
+            \        len(s:placeholder_texts) - str2nr(submatch(1)), ''
             \), \"'\", \"''\", 'g') . \"'\"", 'g')
         " evaluate what's left
         let @s=eval(@s)

--- a/autoload/minisnip.vim
+++ b/autoload/minisnip.vim
@@ -151,7 +151,9 @@ function! s:SelectPlaceholder() abort
         let @s=substitute(@s, '\V' . g:minisnip_backrefmarker . '\(\d\)',
             \"\\=\"'\" . substitute(get(
             \    s:placeholder_texts,
-            \    len(s:placeholder_texts) - str2nr(submatch(1)), ''
+            \    g:minisnip_backreffirst ?
+						\        str2nr(submatch(1)) :
+						\        len(s:placeholder_texts) - str2nr(submatch(1)), ''
             \), \"'\", \"''\", 'g') . \"'\"", 'g')
         " evaluate what's left
         let @s=eval(@s)

--- a/doc/minisnip.txt
+++ b/doc/minisnip.txt
@@ -123,8 +123,8 @@ Default: '\\~'
 
 When this is present, followed by a single digit `n`, in a placeholder that
 also starts with |'g:minisnip_evalmarker'|, it will be replaced with the `n`th
-to last previous placeholder value, surrounded by quotes. Here is an example
-of how it can be used: >
+placeholder value, according to |'g:minisnip_backreffirst'|, surrounded by
+quotes. Here is an example of how it can be used: >
     #ifndef {{+INCLUDE_GUARD+}}
     #define {{+~\~1+}}
 
@@ -134,6 +134,14 @@ of how it can be used: >
 <
 This will automatically fill the `#define` line with the value entered on the
 `#ifndef` line upon jumping to it.
+
+-------------------------------------------------------------------------------
+                                                   *'g:minisnip_backreffirst'*
+Default: 0
+
+If set to 0, backreferences will be replaced with the `n`th to last
+placeholder value. If set to a non 0 value, the `n`th from first placeholder
+will be used instead.
 
 -------------------------------------------------------------------------------
                                                  *'g:minisnip_finalstartdelim'*

--- a/plugin/minisnip.vim
+++ b/plugin/minisnip.vim
@@ -14,6 +14,7 @@ let g:minisnip_finalenddelim = get(g:, 'minisnip_finalenddelim', '-}}')
 let g:minisnip_evalmarker = get(g:, 'minisnip_evalmarker', '~')
 let g:minisnip_donotskipmarker = get(g:, 'minisnip_donotskipmarker', '`')
 let g:minisnip_backrefmarker = get(g:, 'minisnip_backrefmarker', '\\~')
+let g:minisnip_backreffirst = get(g:, 'minisnip_backreffirst', 0)
 
 " this is the pattern used to find placeholders
 let g:minisnip_delimpat = '\V' . g:minisnip_startdelim . '\.\{-}' . g:minisnip_enddelim

--- a/syntax/minisnip.vim
+++ b/syntax/minisnip.vim
@@ -26,6 +26,8 @@ endif
 " Get the minisnip defined delimiters
 exe "syntax match minisnipKeyword /" . g:minisnip_startdelim . "/"
 exe "syntax match minisnipKeyword /" . g:minisnip_enddelim . "/"
+exe "syntax match minisnipKeyword /" . g:minisnip_finalstartdelim . "/"
+exe "syntax match minisnipKeyword /" . g:minisnip_finalenddelim . "/"
 
 highlight default link minisnipKeyword Keyword
 


### PR DESCRIPTION
I found a little awkward that in minisnip, the backreference count start from last. I added an option to choose if you want the original behaviour (default) or you want the backreference count from first, like in other snippet plugins. Just add in vimrc:
`let g:minisnip_backreffirst = 1` 
Of course existing snippets must be adapted to work with this option.